### PR TITLE
Fix private Docker Hub repository access in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
     needs: build
     runs-on: self-hosted
     steps:
+      - name: Login to docker hub
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
       - name: Pull image from docker hub
         run: docker pull kirarwa/ist-feedback:latest
       - name: Delete old container


### PR DESCRIPTION
This pull request fixes an issue where the GitHub Actions workflow fails to pull the Docker image from a private Docker Hub repository due to missing authentication in the deploy job. 

### Changes:
- Added a `docker login` step in the `deploy` job to ensure the runner is authenticated before pulling the image from Docker Hub.
- Maintained the `docker login` step in the `build` job for pushing the image.
- Ensured consistency in the Docker repository name and image tags during the build and deploy steps.

This fix ensures that the workflow can successfully pull images from a private Docker Hub repository during deployment.