### PR TITLE
Fix Docker exec command for running migrations and seeders in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Run docker container
         run: docker run -d -p 3000:3000 --name nextjs-app-container kirarwa/ist-feedback
       - name: Run migrations
-        run: docker exec -it nextjs-app-container npm run migrate
+        run: docker exec nextjs-app-container npm run migrate
       - name: Run seeders
-        run: docker exec -it nextjs-app-container npm run seed 
+        run: docker exec nextjs-app-container npm run seed 


### PR DESCRIPTION
This pull request fixes an issue with running database migrations and seeders in the GitHub Actions deployment workflow. 

### Key Changes:
- Removed the `-it` flag from the `docker exec` commands used to run migrations (`npm run migrate`) and seeders (`npm run seed`). 
- This change allows the commands to execute correctly in the non-interactive environment of GitHub Actions, resolving the `the input device is not a TTY` error.

With this fix, the deployment process will now successfully run database migrations and seed data automatically, ensuring that the application is in sync with the database schema after each deployment.
