### PR TITLE
Merge main into development after fixing Docker exec command for migrations and seeders

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Run docker container
         run: docker run -d -p 3000:3000 --name nextjs-app-container kirarwa/ist-feedback
       - name: Run migrations
-        run: docker exec -it nextjs-app-container npm run migrate
+        run: docker exec nextjs-app-container npm run migrate
       - name: Run seeders
-        run: docker exec -it nextjs-app-container npm run seed 
+        run: docker exec nextjs-app-container npm run seed 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,4 +46,8 @@ jobs:
       - name: Delete old container
         run: docker rm -f nextjs-app-container  
       - name: Run docker container
-        run: docker run -d -p 3000:3000 --name nextjs-app-container kirarwa/ist-feedback 
+        run: docker run -d -p 3000:3000 --name nextjs-app-container kirarwa/ist-feedback
+      - name: Run migrations
+        run: docker exec -it nextjs-app-container npm run migrate
+      - name: Run seeders
+        run: docker exec -it nextjs-app-container npm run seed 


### PR DESCRIPTION
This pull request merges the latest changes from the `main` branch into the `development` branch, which includes a fix for running database migrations and seeders in the GitHub Actions deployment workflow.

### Key Changes:
- Removed the `-it` flag from the `docker exec` commands used for running migrations (`npm run migrate`) and seeders (`npm run seed`). 
- This adjustment resolves the `the input device is not a TTY` error encountered during the execution in the GitHub Actions environment.

This merge ensures that the `development` branch is up-to-date with these critical workflow improvements, allowing for successful execution of database migrations and seed data during the deployment process.
