### PR TITLE
Fix/permissions to control view and create

### DIFF
--- a/database/migrations/20241207073713-users-notifications.ts
+++ b/database/migrations/20241207073713-users-notifications.ts
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface: any, Sequelize: any) => {
+    await queryInterface.createTable('Notifications', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      title: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      message: {
+        type: Sequelize.TEXT, // Use TEXT for potentially longer messages
+        allowNull: false,
+      },
+      link: {
+        type: Sequelize.STRING, // Optional link for actions
+        allowNull: true,
+      },
+      status: {
+        type: Sequelize.ENUM('unread', 'read', 'archived'),
+        allowNull: false,
+        defaultValue: 'unread',
+      },
+      priority: {
+        type: Sequelize.ENUM('low', 'normal', 'high'),
+        allowNull: false,
+        defaultValue: 'normal',
+      },
+      expiresAt: {
+        type: Sequelize.DATE,
+        allowNull: true, // Nullable for non-expiring notifications
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+  down: async (queryInterface: any) => {
+    await queryInterface.dropTable('Notifications'); // Correct table name
+  },
+};

--- a/database/migrations/20241207100159-update-users-table.ts
+++ b/database/migrations/20241207100159-update-users-table.ts
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface: any, Sequelize: any) {
+    // Add the 'acceptInvite' column to the 'users' table
+    await queryInterface.addColumn('Users', 'acceptInvite', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false, // Set the default value to false
+      allowNull: false, // Make it non-nullable
+    });
+  },
+
+  async down (queryInterface: any, Sequelize: any) {
+    // Remove the 'acceptInvite' column from the 'users' table
+    await queryInterface.removeColumn('users', 'acceptInvite');
+  }
+};
+

--- a/database/seeders/20240926102653-seed-roles-permissions.ts
+++ b/database/seeders/20240926102653-seed-roles-permissions.ts
@@ -93,6 +93,9 @@ export default {
 
       MANAGE_PROFILE='manage_profile',//61
       MANAGE_FEEDBACK_QUESTIONS= 'manage_feedback_questions',//62
+
+      CREATE_FEEDBACKS='create_feedbacks', //63
+      CREATE_MODULES='create_modules' //64
     }
 
     // Hash passwords
@@ -244,6 +247,10 @@ export default {
       { roleId: 4, permissionId: 58, createdAt: new Date(), updatedAt: new Date() },
       { roleId: 4, permissionId: 60, createdAt: new Date(), updatedAt: new Date() },
       { roleId: 4, permissionId: 61, createdAt: new Date(), updatedAt: new Date() },
+
+      //update_admin
+      { roleId: 2, permissionId: 63, createdAt: new Date(), updatedAt: new Date() },
+      { roleId: 2, permissionId: 64, createdAt: new Date(), updatedAt: new Date() },
 ]);
 
 

--- a/database/seeders/20240926102653-seed-roles-permissions.ts
+++ b/database/seeders/20240926102653-seed-roles-permissions.ts
@@ -139,6 +139,7 @@ export default {
         email: 'sam@example.com',
         password: hashedPasswordSam, // Hashed password for Sam
         roleId: 2, // Assuming the ID for ADMIN is automatically set to 2
+        acceptInvite:true,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
@@ -147,6 +148,7 @@ export default {
         email: 'admin@example.com',
         password: hashedPasswordAdmin, // Hashed password for Admin
         roleId: 1, // Assuming the ID for SUPER_ADMIN is automatically set to 1
+        acceptInvite:true,
         createdAt: new Date(),
         updatedAt: new Date(),
       },

--- a/emails/inviteUser.tsx
+++ b/emails/inviteUser.tsx
@@ -1,163 +1,155 @@
 import {
-    Body,
-    Container,
-    Column,
-    Head,
-    Html,
-    Img,
-    Link,
-    Preview,
-    Row,
-    Section,
-    Text,
-    Button,
-  } from "@react-email/components";
-  import * as React from "react";
-  
-  interface EmailTemplateProps {
-    username?: string;
-    inviteLink?: string;
-  }
-  
-  const baseUrl = process.env.URL
-    ? `http://localhost:3000/`
-    : "";
-  
-  export const InviteUserEmail = ({
-    username,
-    inviteLink
-  }: EmailTemplateProps) => {
-    return (
-      <Html>
-        <Head />
-        <Preview>You've been invited to join the Institute of Software Technologies!</Preview>
-        <Body style={main}>
-          <Container style={container}>
+  Body,
+  Container,
+  Head,
+  Html,
+  Img,
+  Preview,
+  Row,
+  Section,
+  Text,
+  Button,
+} from "@react-email/components";
+import * as React from "react";
+
+interface EmailTemplateProps {
+  username?: string;
+  inviteLink?: string;
+}
+
+export const InviteUserEmail = ({
+  username,
+  inviteLink,
+}: EmailTemplateProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>You&apos;ve been invited to join the Institute of Software Technologies!</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {/* Centered Logo */}
+         
             <Section style={logo}>
-              <Img width={100} src={`https://raw.githubusercontent.com/Institue-of-software-technologies/ist-feedback/refs/heads/main/public/assets/image/logo.png`} />
-            </Section>
-            <Section style={sectionsBorders}>
-              <Row>
-                <Column style={sectionBorder} />
-                <Column style={sectionCenter} />
-                <Column style={sectionBorder} />
+              <Row style={icon}>
+                <Img
+                  style={{display:"inline-block"}}
+                  width={100}
+                  src={`https://raw.githubusercontent.com/Institue-of-software-technologies/ist-feedback/refs/heads/main/public/assets/image/logo.png`}
+                  alt="Institute of Software Technologies Logo"
+                />
               </Row>
             </Section>
-            <Section style={content}>
-              <Text style={paragraph}>Hi {username},</Text>
-              <Text style={paragraph}>
-                We are excited to invite you to join the Institute of Software Technologies. Click the button below to accept your invitation and get started!
-              </Text>
-              <Section>
-                <Row style={rowStyle}>
-                  <Button style={button} href={inviteLink}>
-                    Accept Invitation
-                  </Button>
-                </Row>
-              </Section>
-              <Text style={paragraph}>
-                If you have any questions, feel free to reach out to our support team.
-              </Text>
-              <Text style={paragraph}>
-                Thanks,
-                <br />
-                Institute of Software Technologies Support Team
-              </Text>
+          
+
+          {/* Email Content */}
+          <Section style={content}>
+            <Text style={paragraph}>Hi {username},</Text>
+            <Text style={paragraph}>
+              We are excited to invite you to join the Institute of Software Technologies. Click the button below to accept your invitation and get started!
+            </Text>
+
+            {/* Centered Button */}
+            <Section>
+              <Row style={rowStyle}>
+                <Button style={button} href={inviteLink}>
+                  Accept Invitation
+                </Button>
+              </Row>
             </Section>
-          </Container>
-  
-          <Section style={footer}>
-            <Row>
-              <Text style={{ textAlign: "center", color: "#706a7b" }}>
-                © 2024 Institute of Software Technologies. All rights reserved. <br />
-                Mpaka Rd, 6th floor West Point Building, 6th Floor, Parklands
-              </Text>
-            </Row>
+
+            <Text style={paragraph}>
+              If you have any questions, feel free to reach out to our support team.
+            </Text>
+            <Text style={paragraph}>
+              Thanks,
+              <br />
+              Institute of Software Technologies Support Team
+            </Text>
           </Section>
-        </Body>
-      </Html>
-    );
-  };
-  
-  InviteUserEmail.PreviewProps = {
-    username: "alanturing",
-    inviteLink: "http://example.com/invite", // Placeholder link
-  } as EmailTemplateProps;
-  
-  export default InviteUserEmail;
-  
-  const fontFamily = "HelveticaNeue,Helvetica,Arial,sans-serif";
-  
-  const main = {
-    backgroundColor: "#efeef1",
-    fontFamily,
-  };
-  
-  const paragraph = {
-    lineHeight: 1.5,
-    fontSize: 14,
-  };
-  
-  const container = {
-    maxWidth: "580px",
-    margin: "40px auto",
-    backgroundColor: "#ffffff",
-  };
-  
-  const footer = {
-    maxWidth: "580px",
-    margin: "0 auto",
-  };
-  
-  const content = {
-    padding: "5px 20px 10px 20px",
-  };
-  
-  const logo = {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-  };
-  
-  const sectionsBorders = {
-    width: "100%",
-    display: "flex",
-  };
-  
-  const sectionBorder = {
-    borderBottom: "1px solid #82929",
-    width: "249px",
-  };
-  
-  const sectionCenter = {
-    borderBottom: "1px solid #E82929",
-    width: "102px",
-  };
-  
-  const link = {
-    textDecoration: "underline",
-  };
-  
-  const button = {
-    backgroundColor: "#E82929",
-    borderRadius: "4px",
-    color: "#fff",
-    fontFamily: "'Open Sans', 'Helvetica Neue', Arial",
-    fontSize: "15px",
-    textDecoration: "none",
-    textAlign: "center" as const,
-    display: "block", // Ensures the button takes full width
-    width: "210px",
-    padding: "14px 7px",
-    margin: "20px auto", // Adds vertical margin and centers button
-    cursor: "pointer",
-  };
-  
-  const rowStyle = {
-    display: "flex",
-    justifyContent: "center", // Horizontally centers the button
-    alignItems: "center", // Vertically centers content (optional)
-    width: "100%", // Ensures full width of the row container
-  };
-  
+        </Container>
+
+        {/* Footer */}
+        <Section style={footer}>
+          <Row>
+            <Text style={{ textAlign: "center", color: "#706a7b" }}>
+              © 2024 Institute of Software Technologies. All rights reserved. <br />
+              Mpaka Rd, 6th floor West Point Building, 6th Floor, Parklands
+            </Text>
+          </Row>
+        </Section>
+      </Body>
+    </Html>
+  );
+};
+
+InviteUserEmail.PreviewProps = {
+  username: "alanturing",
+  inviteLink: "http://example.com/invite", // Placeholder link
+} as EmailTemplateProps;
+
+export default InviteUserEmail;
+
+const fontFamily = "HelveticaNeue,Helvetica,Arial,sans-serif";
+
+const main = {
+  backgroundColor: "#efeef1",
+  fontFamily,
+};
+
+const paragraph = {
+  lineHeight: 1.5,
+  fontSize: 14,
+};
+
+const container = {
+  maxWidth: "580px",
+  margin: "40px auto",
+  backgroundColor: "#ffffff",
+  borderRadius: "8px", // Added rounded corners for better design
+  boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)", // Subtle shadow for better contrast
+};
+
+const footer = {
+  maxWidth: "580px",
+  margin: "20px auto 0",
+  textAlign: "center" as const,
+};
+
+const content = {
+  padding: "20px",
+};
+
+const logo = {
+  display: "flex",
+  justifyContent: "center", // Centers the logo horizontally
+  alignItems: "center", // Centers the logo vertically
+  padding: "20px",
+};
+
+const button = {
+  backgroundColor: "#E82929",
+  borderRadius: "4px",
+  color: "#fff",
+  fontFamily: "'Open Sans', 'Helvetica Neue', Arial",
+  fontSize: "15px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block", // Ensures the button takes full width
+  width: "210px",
+  padding: "14px 7px",
+  margin: "20px auto", // Adds vertical margin and centers button
+  cursor: "pointer",
+};
+
+const rowStyle = {
+  display: "flex",
+  justifyContent: "center", // Horizontally centers the button
+  alignItems: "center", // Vertically centers content (optional)
+  width: "100%", // Ensures full width of the row container
+};
+
+const icon = {
+  display: "flex",
+  justifyContent: "center",/* Centers items horizontally */
+  alignItems: "center", /* Centers items vertically */
+};

--- a/emails/resetPassword.tsx
+++ b/emails/resetPassword.tsx
@@ -1,7 +1,6 @@
 import {
   Body,
   Container,
-  Column,
   Head,
   Html,
   Img,
@@ -38,13 +37,6 @@ export const ResetPasswordEmail = ({
         <Container style={container}>
           <Section style={logo}>
             <Img width={100} src={`https://raw.githubusercontent.com/Institue-of-software-technologies/ist-feedback/refs/heads/main/public/assets/image/logo.png`} />
-          </Section>
-          <Section style={sectionsBorders}>
-            <Row>
-              <Column style={sectionBorder} />
-              <Column style={sectionCenter} />
-              <Column style={sectionBorder} />
-            </Row>
           </Section>
           <Section style={content}>
             <Text style={paragraph}>Hi {username},</Text>
@@ -141,21 +133,6 @@ const logo = {
   justifyContent: "center",
   alignItems: "center",
   padding: 20,
-};
-
-const sectionsBorders = {
-  width: "100%",
-  display: "flex",
-};
-
-const sectionBorder = {
-  borderBottom: "1px solid #82929",
-  width: "249px",
-};
-
-const sectionCenter = {
-  borderBottom: "1px solid #E82929",
-  width: "102px",
 };
 
 const link = {

--- a/emails/sendPDF.tsx
+++ b/emails/sendPDF.tsx
@@ -1,7 +1,6 @@
 import {
   Body,
   Container,
-  Column,
   Head,
   Html,
   Img,
@@ -34,13 +33,6 @@ export const ReportEmail = ({
         <Container style={container}>
           <Section style={logo}>
             <Img width={100} src={`https://raw.githubusercontent.com/Institue-of-software-technologies/ist-feedback/refs/heads/main/public/assets/image/logo.png`} />
-          </Section>
-          <Section style={sectionsBorders}>
-            <Row>
-              <Column style={sectionBorder} />
-              <Column style={sectionCenter} />
-              <Column style={sectionBorder} />
-            </Row>
           </Section>
           <Section style={content}>
             <Text style={paragraph}>Hello {trainerName},</Text>
@@ -118,16 +110,4 @@ const logo = {
   justifyContent: "center",
   alignItems: "center",
   padding: 20,
-};
-const sectionsBorders = {
-  width: "100%",
-  display: "flex",
-};
-const sectionBorder = {
-  borderBottom: "1px solid #82929",
-  width: "249px",
-};
-const sectionCenter = {
-  borderBottom: "1px solid #E82929",
-  width: "102px",
 };

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,6 +7,9 @@ import { useRouter } from "next/navigation";
 import { useUser } from '@/context/UserContext';
 import api from '../../../../lib/axios';
 import { ToastContainer } from 'react-toastify';
+import { showToast } from '@/components/ToastMessage';
+import 'react-toastify/dist/ReactToastify.css';
+import axios from 'axios';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -24,27 +27,38 @@ export default function LoginPage() {
       const response = await api.post('/auth/login', {
         email: email,
         password: password,
-        rememberMe: rememberMe
+        rememberMe: rememberMe,
       });
-
+  
       const useRolesPermissions = response.data.client;
-
+  
       router.push('/dashboard');
       localStorage.setItem('userRolesPermissions', JSON.stringify(useRolesPermissions));
       setUser(useRolesPermissions);
-
-
+  
       if (response.status !== 200) {
         throw new Error(`error: ${response.data.message}`);
       }
-
-    } catch (error) {
+  
+    } catch (error: unknown) {
       console.error('Login failed', error);
-      alert('Invalid credentials');
+  
+      if (axios.isAxiosError(error)) {
+        // Extract and display the error message if it's an AxiosError
+        const errorMessage = error.response?.data?.message || 'An unexpected error occurred';
+        showToast.error(`${errorMessage}`);
+      } else if (error instanceof Error) {
+        // Handle other types of errors
+        showToast.error(`${error.message}`);
+      } else {
+        // Handle unexpected error types
+        showToast.error('An unexpected error occurred');
+      }
     } finally {
       setIsLoading(false); // Stop loading once the request is done
     }
   };
+  
   
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">

--- a/src/app/(auth)/reset-forgot-password/page.tsx
+++ b/src/app/(auth)/reset-forgot-password/page.tsx
@@ -28,12 +28,10 @@ export default function ResetPassword() {
       try {
         const response = await api.get(`/auth/reset-password/${token}`);
         if (response.status === 200) {
-          showToast.success(response.data.message);
           setTokenAuthenticated(true);
         }
       } catch (error) {
         console.log(error);
-        showToast.error('Reset token is invalid');
         setTokenAuthenticated(false);
       } finally {
         setIsLoading(false);

--- a/src/app/(auth)/reset-password-invite/page.tsx
+++ b/src/app/(auth)/reset-password-invite/page.tsx
@@ -1,0 +1,235 @@
+"use client"
+import { useEffect, useState } from "react";
+import { ToastContainer } from "react-toastify";
+import api from "../../../../lib/axios";
+import { useRouter, useSearchParams } from "next/navigation";
+import 'react-toastify/dist/ReactToastify.css';
+import { showToast } from "@/components/ToastMessage";
+import Form from "@/components/Forms";
+import Loading from '@/app/loading';
+import { User } from "@/types";
+
+interface FormData {
+  NewPassword: string;
+  ConfirmPassword: string;
+}
+
+export default function ResetPassword() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
+  const [tokenAuthenticated, setTokenAuthenticated] = useState<boolean>(false);
+  const [user, setUser] = useState<User | null>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const email = searchParams.get('email');
+  const userId = searchParams.get('user');
+
+
+  useEffect(() => {
+    const checkResetToken = async () => {
+      try {
+        const response = await api.get(`/auth/reset-password/${token}`);
+        if (response.status === 200) {
+          setTokenAuthenticated(true);
+        }
+      } catch (error) {
+        console.log(error);
+        setTokenAuthenticated(false);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    checkResetToken();
+    const fetchUser = async () => {
+      try {
+        const response = await api.get(`/users/${userId}`);
+        setUser(response.data.user);
+        console.log(response.data.user);
+      } catch (err) {
+        console.log(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchUser();
+
+  }, [router, token,userId]);
+
+  const handleSubmit = async (data: FormData) => {
+    console.log(data);
+    setFormLoading(true);
+
+    const passwordRegex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/);
+
+    // Validate password strength
+    if (!passwordRegex.test(data.NewPassword)) {
+      showToast.error(
+        "Password must be at least 8 characters long, contain uppercase, lowercase, a digit, and a special character.",
+        { position: "top-right", autoClose: 4000 }
+      );
+      setIsLoading(false);
+      setFormLoading(false);
+      return;
+    }
+
+    // Check if the passwords match
+    if (data.NewPassword !== data.ConfirmPassword) {
+      showToast.error("Passwords do not match!");
+      setIsLoading(false);
+      setFormLoading(false);
+      return;
+    }
+
+    try {
+      const password = data.NewPassword;
+      const response = await api.post('/auth/reset-password', { token, email, password });
+
+      if (response.status === 200) {
+        showToast.success(response.data.message);
+        setTimeout(() => {
+          router.push('/login'); // Navigate only on success
+        }, 3000);
+      } else {
+        showToast.error(response.data.message || 'Password reset failed.');
+      }
+    } catch (error: unknown) {
+      console.error(error);
+      showToast.error('Invalid token or server error');
+    } finally {
+      setIsLoading(false);
+      setFormLoading(false);
+    }
+  };
+
+  const sendNotification = async () => {
+    setLoading(true);
+    try {
+      const response = await api.post('/notification',
+        {
+          title: 'Password Reset Link Request',
+          message: `User with the email ${email} has requested to resend the password reset link.`,
+          priority: 'normal',
+          email: email
+        });
+      if (response.status === 201) {
+        showToast.success("Notification send successfully");
+        setTimeout(() => {
+          router.push('/login'); // Redirect to the user list
+        }, 2000);
+      }
+    } catch (err) {
+      console.error(err);
+      showToast.error('Invalid token or server error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inputs = [
+    { label: "NewPassword", type: "password" },
+    { label: "ConfirmPassword", type: "password" }
+  ];
+
+  if (isLoading) return <Loading />
+
+  if (user && user.acceptInvite) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen p-8 bg-gray-100">
+        <div className="bg-white shadow-md rounded-lg p-6 text-center max-w-lg w-full">
+          <h1 className="text-2xl font-semibold text-green-600">Invite Already Accepted</h1>
+          <p className="mt-2 text-gray-500">
+            You have already accepted the invitation. Please proceed to log in with your credentials.
+          </p>
+          <button
+            onClick={() => router.push('/login')}
+            className="mt-4 bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 transition"
+          >
+            Go to Login
+          </button>
+          <p className="mt-2 text-gray-400 text-sm">
+            If you need assistance, please contact support.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <ToastContainer />
+      {tokenAuthenticated ? (
+        <div className="bg-white shadow-md rounded-lg p-8 max-w-sm w-full">
+          <div className="text-center">
+
+            {/* Welcome Back and Login Section */}
+            <h1 className="font-medium mt-4 mb-2 text-black">
+              <b>Reset password</b>
+            </h1>
+
+            <h5 className="text-gray-600 mt-2">
+              Enter you new password for <span style={{ color: "#DC2626" }}><b>{email}</b></span>
+            </h5>
+          </div>
+          <Form<FormData>
+            Input={inputs}
+            onSubmit={handleSubmit}
+            buttonColor="bg-red-600"
+            buttonText="Reset password"
+            loading={formLoading}
+            hoverColor="hover:bg-red-700"
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center min-h-screen p-8 bg-gray-100">
+          <div className="bg-white shadow-md rounded-lg p-6 text-center max-w-lg w-full">
+            <h1 className="text-2xl font-semibold text-red-600">Invitation Link Expired</h1>
+            <p className="mt-2 text-gray-500">
+              The invitation link you received has expired. Please click the button below to notify the admin to resend a new link.
+            </p>
+            <button
+              type="submit"
+              onClick={sendNotification}
+              className={`bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
+              disabled={loading} // Disable button while loading
+            >
+              {loading ? (
+                <div className="flex items-center">
+                  <svg
+                    className="animate-spin h-5 w-5 mr-2 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                    ></path>
+                  </svg>
+                  sending notification...
+                </div>
+
+              ) : (
+                "Notify Admin to Resend Link"
+              )}
+            </button>
+            <p className="mt-2 text-gray-400 text-sm">
+              If you have any questions, please contact support.
+            </p>
+          </div>
+        </div>
+      )}
+
+    </div>
+  )
+}

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
          })
  
          // Send the email with reset link including the token
-        const customLink = `${URL}/reset-password?token=${resetToken}&email=${email}`;
+        const customLink = `${URL}/reset-forgot-password?token=${resetToken}&email=${email}`;
 
         // Create transport for Gmail
         const transporter = nodemailer.createTransport({

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
       );
     }
     if (!findUser.acceptInvite) {
-      return NextResponse.json({ message: 'User has not accepted the invite' }, { status: 400 });
+      return NextResponse.json({ message: 'Please accept the invitation sent to your email.' }, { status: 400 });
     }
 
     const passwordValidation = await bcrypt.compare(

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -25,6 +25,9 @@ export async function POST(req: Request) {
         { status: 401 }
       );
     }
+    if (!findUser.acceptInvite) {
+      return NextResponse.json({ message: 'User has not accepted the invite' }, { status: 400 });
+    }
 
     const passwordValidation = await bcrypt.compare(
       password,

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -32,6 +32,7 @@ export async function POST(request: NextRequest) {
     const hashedPassword = await bcrypt.hash(password, 10);
     // Update the user's password
     user.password = hashedPassword;
+    user.acceptInvite = true;
     await user.save();
 
     // Delete the password reset token once the password is updated

--- a/src/app/api/notification/[notificationId]/route.ts
+++ b/src/app/api/notification/[notificationId]/route.ts
@@ -1,0 +1,55 @@
+import Notification from "@/db/models/Notification";
+import { NextRequest, NextResponse } from "next/server";
+
+interface Context {
+  params: { notificationId: number };
+}
+
+// DELETE /api/class-Times/[classTimesId] - Delete a class-Times by ID
+export async function DELETE(req: NextRequest, context: Context) {
+  try {
+    const { notificationId } = context.params;
+    const notification = await Notification.findByPk(notificationId);
+
+    if (!notification) {
+      return NextResponse.json({ message: 'notification not found' }, { status: 404 });
+    }
+
+    await notification.destroy();
+
+    return NextResponse.json({ message: 'class Times deleted successfully' });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ message: 'Error deleting Class Times', error: errorMessage }, { status: 500 });
+  }
+}
+export async function PUT(req: NextRequest, context: Context) {
+  try {
+    const { notificationId } = context.params;
+    const { status } = await req.json(); // Assume that status is passed in the request body
+
+    // Validate status input (e.g., "read" or "unread")
+    if (status !== 'read' && status !== 'unread') {
+      return NextResponse.json(
+        { message: 'Invalid status value. Use "read" or "unread".' },
+        { status: 400 }
+      );
+    }
+
+    // Find the notification by ID
+    const notification = await Notification.findByPk(notificationId);
+
+    if (!notification) {
+      return NextResponse.json({ message: 'Notification not found' }, { status: 404 });
+    }
+
+    // Update the status of the notification
+    notification.status = status;
+    await notification.save();
+
+    return NextResponse.json({ message: 'Notification status updated successfully' });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ message: 'Error updating notification status', error: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/notification/route.ts
+++ b/src/app/api/notification/route.ts
@@ -1,0 +1,76 @@
+import { User } from '@/db/models';
+import Notification from '@/db/models/Notification';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    // Parse the request body
+    const { title, message, priority, expiresAt,email } = await req.json();
+
+    const userRecipient = await User.findOne({where:{roleId:1}})
+    const userSender = await User.findOne({where:{email:email}})
+
+    if (!title || typeof title !== 'string') {
+      return NextResponse.json(
+        { message: 'Invalid input: title is required and must be a string.' },
+        { status: 400 }
+      );
+    }
+    if (!message || typeof message !== 'string') {
+      return NextResponse.json(
+        { message: 'Invalid input: message is required and must be a string.' },
+        { status: 400 }
+      );
+    }
+    if (priority && !['low', 'normal', 'high'].includes(priority)) {
+      return NextResponse.json(
+        { message: 'Invalid input: priority must be one of "low", "normal", or "high".' },
+        { status: 400 }
+      );
+    }
+
+    // Create the notification
+    const notification = await Notification.create({
+      userId:userRecipient?.id,
+      title,
+      message,
+      link:`/dashboard/users/edit/${userSender?.id}`,
+      priority: priority || 'normal', // Default to 'normal' if not provided
+      expiresAt: expiresAt ? new Date(expiresAt) : null, // Parse expiresAt to a date or set it null
+    });
+
+    // Return a success response
+    return NextResponse.json(
+      { message: 'Notification created successfully', notification },
+      { status: 201 }
+    );
+  } catch (error) {
+    // Handle errors
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json(
+      { message: 'Error creating notification', error: errorMessage },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const userId = req.headers.get("user-id");
+  try {
+    // Fetch all notifications from the database
+    const notifications = await Notification.findAll({where:{userId:userId}});
+
+    // Return the notifications in the response
+    return NextResponse.json(
+      { message: 'Notifications fetched successfully', notifications },
+      { status: 200 }
+    );
+  } catch (error) {
+    // Handle errors
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json(
+      { message: 'Error fetching notifications', error: errorMessage },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/roles/[roleId]/route.ts
+++ b/src/app/api/roles/[roleId]/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest, context: Context) {
 export async function PUT(req: NextRequest, context: Context) {
   try {
     const { roleId } = context.params;
-    const { roleName, multiSelectField,Permissions } = await req.json();
+    const { roleName, multiSelectField } = await req.json();
     console.log(roleName, multiSelectField);
 
     // Fetch the role by ID
@@ -64,7 +64,7 @@ export async function PUT(req: NextRequest, context: Context) {
     }
 
     // Update permissions only if provided
-    if (Permissions.length > 0) {
+    if (multiSelectField.length > 0) {
       // Clear existing permissions
       await RolePermission.destroy({
         where: {

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -116,3 +116,6 @@ export async function DELETE(req: Request, { params }: { params: { userId: strin
     return NextResponse.json({ message: 'Error deleting user', error }, { status: 500 });
   }
 }
+
+
+

--- a/src/app/api/users/resend-invite/route.ts
+++ b/src/app/api/users/resend-invite/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
+import crypto from 'crypto';
+import { User } from '@/db/models';
+import { PasswordReset } from '@/db/models/PasswordReset';
+import { render } from '@react-email/components';
+import InviteUserEmail from '../../../../../emails/inviteUser';
+
+const users = process.env.MAIL_USERNAME;
+const pass = process.env.MAIL_PASSWORD;
+const URL = process.env.URL;
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { email } = body;
+
+    const user = await User.findOne({ where: { email } });
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    await PasswordReset.destroy({
+      where: { email },
+    });
+
+    const resetToken = crypto.randomBytes(32).toString('hex');
+    const tokenExpiration = Date.now() + 5 * 60 * 1000;
+
+    await PasswordReset.upsert({
+      email,
+      token: resetToken,
+      expires: tokenExpiration,
+    });
+
+    const customLink = `${URL}/reset-password-invite?token=${resetToken}&email=${email}&user=${user.id}`;
+
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.googlemail.com',
+      port: 587,
+      secure: false, // Use TLS with port 587
+      auth: {
+        user: users, // Corrected property
+        pass,        // Correct password
+      },
+      tls: {
+        rejectUnauthorized: false, // Allows self-signed certificates (use with caution)
+      },
+    });
+
+    const view = await render(
+      InviteUserEmail({ username: user.username, inviteLink: customLink })
+    );
+
+    await transporter.sendMail({
+      from: users,
+      to: email,
+      subject: 'Resend Invitation Token',
+      html: view,
+    });
+
+    return NextResponse.json(
+      { message: 'Invitation token resent successfully' },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error(error); // Log error for debugging
+    return NextResponse.json(
+      { message: 'Error resending invitation token', error: error },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -78,7 +78,7 @@ export async function POST(req: Request) {
       expires: tokenExpiration
     })
 
-    const customLink = `${URL}/reset-password?token=${resetToken}&email=${email}`;
+    const customLink = `${URL}/reset-password-invite?token=${resetToken}&email=${email}`;
 
     // Create transport for Gmail
     const transporter = nodemailer.createTransport({

--- a/src/app/dashboard/@analytics/default.tsx
+++ b/src/app/dashboard/@analytics/default.tsx
@@ -22,8 +22,10 @@ interface FeedbackReport {
         questionType: string;  // Type of the question (e.g., "Multiple Choice")
     };
     feedback: {
-        trainer: {
-            username: string;  // Trainer's username
+        courseTrainer: {
+            trainers_users: {
+                username: string;  // Trainer's username
+            };
         };
     };
 }
@@ -58,7 +60,7 @@ const FeedbackDashboard = () => {
             questionCounts[questionType] = (questionCounts[questionType] || 0) + 1;
 
             // Aggregate feedback per trainer
-            const trainerName = report.feedback.trainer.username;
+            const trainerName = report.feedback.courseTrainer.trainers_users.username;
             feedbackPerTrainer[trainerName] = (feedbackPerTrainer[trainerName] || 0) + 1;
         });
 

--- a/src/app/dashboard/class-times/create/page.tsx
+++ b/src/app/dashboard/class-times/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import 'react-toastify/dist/ReactToastify.css';
 import Form from "@/components/Forms";
 import api from "../../../../../lib/axios";
@@ -14,7 +14,9 @@ interface FormData {
 
 const NewClassTimeForm: React.FC = () => {
   const router = useRouter();
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/class-times", data);
       showToast.success("class time created successfully!");
@@ -26,8 +28,18 @@ const NewClassTimeForm: React.FC = () => {
       console.error("Failed to create class time", error);
       showToast.error("Failed to create class time");
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/class-times'),
+    }
+  ];
   const inputs = [
     { label: "classTime", type: "text" },
   ];
@@ -39,6 +51,8 @@ const NewClassTimeForm: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/class-times/edit/[classTimesId]/page.tsx
+++ b/src/app/dashboard/class-times/edit/[classTimesId]/page.tsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import Form from '@/components/Forms';
 import { ClassTime } from '@/types';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
   classTimes: string;
@@ -18,6 +19,7 @@ const EditClassTime = () => {
   const { classTimesId } = useParams(); // Get the `userId` from the URL
   const [classTimes, setClassTimes] = useState<ClassTime | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch user data on mount
@@ -41,7 +43,7 @@ const EditClassTime = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
-    console.log(data)
+    setFormLoading(true);
     try {
       await api.put(`/class-times/${classTimesId}`, data);
       showToast.success('Class Time updated successfully!');
@@ -54,13 +56,23 @@ const EditClassTime = () => {
       console.log(err);
       showToast.error('Failed to update Class Times');
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
   const inputs = [
     { label: "classTime", type: "text", value: classTimes?.classTime },
+  ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/class-times'),
+    }
   ];
 
   return (
@@ -71,6 +83,8 @@ const EditClassTime = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={handleSubmit}
+        addButton={extraButtons}
+        loading={formLoading}
       />
     </div>
   );

--- a/src/app/dashboard/courses/create/page.tsx
+++ b/src/app/dashboard/courses/create/page.tsx
@@ -16,12 +16,14 @@ interface FormData {
 const NewCourseForm: React.FC = () => {
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>(true);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   useEffect(()=>{
     setLoading(false);
   },[])
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/courses", data);
       showToast.success("Course created successfully!");
@@ -34,8 +36,17 @@ const NewCourseForm: React.FC = () => {
       showToast.error("Failed to create courses");
     } finally {
       setLoading(false);
+      setFormLoading(false);
     }
   };
+  
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/courses'),
+    }
+  ];
   
   const inputs = [
     { label: "courseName", type: "text" }
@@ -49,6 +60,8 @@ const NewCourseForm: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/courses/edit/[courseId]/page.tsx
+++ b/src/app/dashboard/courses/edit/[courseId]/page.tsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import Form from '@/components/Forms';
 import { Course } from '@/types';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 interface FormData {
   permissionName: string;
 }
@@ -18,6 +19,7 @@ const EditCourse = () => {
   const [course, setCourse] = useState<Course | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   // Fetch user data on mount
   useEffect(() => {
@@ -39,6 +41,7 @@ const EditCourse = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/courses/${courseId}`, data);
       showToast.success('course updated successfully!');
@@ -51,11 +54,22 @@ const EditCourse = () => {
       console.log(err)
       showToast.error('Failed to update course',);
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/courses'),
+    }
+  ];
+  
   const inputs = [
     { label: "courseName", type: "text", value: course?.courseName || "" }
   ];
@@ -68,6 +82,8 @@ const EditCourse = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={handleSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/feedback-questions/create/page.tsx
+++ b/src/app/dashboard/feedback-questions/create/page.tsx
@@ -26,8 +26,10 @@ const FeedbackQuestionCreate: React.FC = () => {
     maxRating: 10,
   });
   const [showDetailsForm, setShowDetailsForm] = useState(false);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/feedback-questions", data);
       showToast.success("Feedback question created successfully!");
@@ -37,6 +39,9 @@ const FeedbackQuestionCreate: React.FC = () => {
     } catch (error) {
       console.error("Failed to create feedback question", error);
       showToast.error("Failed to create feedback question.");
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -108,6 +113,7 @@ const FeedbackQuestionCreate: React.FC = () => {
         <Form<{ questionType: 'open-ended' | 'closed-ended' | 'rating' }>
           Input={typeSelectionInputs}
           onSubmit={handleQuestionTypeSelection}
+          loading={formLoading}
         />
       )}
       {/* Second form based on selected question type */}
@@ -121,6 +127,7 @@ const FeedbackQuestionCreate: React.FC = () => {
           <Form<FormData>
             Input={openEndedInputs}
             onSubmit={onSubmit}
+            loading={formLoading}
           />
           <button
             onClick={handleGoBack}

--- a/src/app/dashboard/feedback-questions/edit/[questionId]/page.tsx
+++ b/src/app/dashboard/feedback-questions/edit/[questionId]/page.tsx
@@ -9,6 +9,7 @@ import Form, { Input } from '@/components/Forms';
 import { FeedbackQuestion } from '@/db/models/FeedbackQuestion';
 import { AnswerOptions } from '@/types';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
   questionText?: string;
@@ -29,6 +30,7 @@ const EditQuestion = () => {
   const [showDetailsForm, setShowDetailsForm] = useState(false); // Whether to show the second form
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   // Fetch feedback question data on mount
   useEffect(() => {
@@ -85,6 +87,7 @@ const EditQuestion = () => {
 
   // Handle the form submission for the second form (open-ended or closed-ended)
   const handleSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/feedback-questions/${questionId}`, {
         ...data,
@@ -102,6 +105,9 @@ const EditQuestion = () => {
       console.log(err)
       showToast.error('Failed to update feedback question');
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
   // Handle the first form submission for selecting the question type
@@ -115,7 +121,7 @@ const EditQuestion = () => {
     setShowDetailsForm(false); // Go back to the first form
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
   // First form for selecting the question type
@@ -160,6 +166,7 @@ const EditQuestion = () => {
           <Form<FormData>
             Input={openEndedInputs}
             onSubmit={handleSubmit}
+            loading={formLoading}
           />
           <button
             onClick={handleGoBack}

--- a/src/app/dashboard/feedback-reports/page.tsx
+++ b/src/app/dashboard/feedback-reports/page.tsx
@@ -9,6 +9,7 @@ import { useUser } from '@/context/UserContext';
 import 'react-toastify/dist/ReactToastify.css';
 import Table from '@/components/Tables';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 const FeedBackManagement: React.FC = () => {
     const { user } = useUser();
@@ -69,9 +70,7 @@ const FeedBackManagement: React.FC = () => {
         router.push(`/dashboard/feedback-reports/${feedback.id}`);
     };
 
-    if (loading) {
-        return <div className="text-center">Loading...</div>;
-    }
+    if (loading) return <Loading />
 
     const columns = [
         { header: 'Student Token', accessor: 'studentToken' },

--- a/src/app/dashboard/feedback/create/page.tsx
+++ b/src/app/dashboard/feedback/create/page.tsx
@@ -30,10 +30,12 @@ const NewFeedbackForm: React.FC = () => {
   const [classTimes, setClassTimes] = useState<ClassTime[]>([]);
   const [modules, setModules] = useState<Module[]>([]);
   const [questions, setQuestions] = useState<FeedbackQuestion[]>([]);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   const [step, setStep] = useState<number>(1);
   const { user } = useUser();
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/feedback", data);
       showToast.success("Feedback created successfully!");
@@ -43,6 +45,9 @@ const NewFeedbackForm: React.FC = () => {
     } catch (error) {
       console.error("Failed to create feedback", error);
       showToast.error("Failed to create feedback");
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -153,6 +158,15 @@ const NewFeedbackForm: React.FC = () => {
     },
   ];
 
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/feedback'),
+    }
+  ];
+  
+
   const handleNextStep = () => setStep((prev) => prev + 1);
   const handlePrevStep = () => setStep((prev) => prev - 1);
 
@@ -162,8 +176,10 @@ const NewFeedbackForm: React.FC = () => {
       <h2 className="text-2xl font-bold mb-4">Create New Feedback - Step {step}</h2>
       <Form<FormData>
         buttonText={step === 1 ? "Next":"Submit"}
+        addButton={step === 1 ?extraButtons: []}
         Input={step === 1 ? step1Inputs : step2Inputs}
         onSubmit={step === 2 ? onSubmit : handleNextStep}
+        loading={formLoading}
       />
       <div className="flex justify-between mt-4">
         {step > 1 && (

--- a/src/app/dashboard/feedback/edit/[feedbackId]/page.tsx
+++ b/src/app/dashboard/feedback/edit/[feedbackId]/page.tsx
@@ -33,6 +33,7 @@ const EditFeedback = () => {
   const [selectedFeedbackQuestions, setSelectedFeedbackQuestions] = useState<number[]>([]);
   const [tokenStartTime, setTokenStartTime] = useState<Date | null>(null);
   const [tokenExpiration, setTokenExpiration] = useState<Date | null>(null);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   useEffect(() => {
     if (feedbackId) {
@@ -81,6 +82,7 @@ const EditFeedback = () => {
   }, []);
 
   const handleFormSubmit = async (data:FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/feedback/${feedbackId}`,data);
       showToast.success('Feedback updated successfully!');
@@ -90,6 +92,9 @@ const EditFeedback = () => {
     } catch (err) {
       console.log(err);
       showToast.error('Failed to update feedback');
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -152,14 +157,24 @@ const EditFeedback = () => {
       valueDate: tokenExpiration,
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/feedback'),
+    }
+  ];
+  
 
   return (
-    <div className="p-6">
+    <div className="max-w-lg mx-auto bg-white p-6 rounded-lg shadow">
       <ToastContainer />
       <h3 className="text-2xl font-bold mb-4">Edit Feedback</h3>
       <Form<FormData>
         Input={inputs}
         onSubmit={handleFormSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/intakes/create/page.tsx
+++ b/src/app/dashboard/intakes/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import 'react-toastify/dist/ReactToastify.css';
 import Form from "@/components/Forms";
 import api from "../../../../../lib/axios";
@@ -15,7 +15,9 @@ interface FormData {
 
 const NewIntakeForm: React.FC = () => {
     const router = useRouter();
+    const [formLoading, setFormLoading] = useState<boolean>(false);
     const onSubmit = async (data: FormData) => {
+        setFormLoading(true);
         try {
             await api.post("/intakes", data);
             showToast.success("Intake created successfully!");
@@ -25,6 +27,9 @@ const NewIntakeForm: React.FC = () => {
         } catch (error) {
             console.error("Failed to create intake", error);
             showToast.error("Failed to create intake");
+        }
+        finally {
+            setFormLoading(false);
         }
     };
 
@@ -46,6 +51,14 @@ const NewIntakeForm: React.FC = () => {
             options: generateYearOptions()
         }
     ];
+    const extraButtons = [
+        {
+          label: 'Back',
+          type: 'button',
+          onClick: () => router.push('/dashboard/intakes'),
+        }
+      ];
+      
 
 
     return (
@@ -55,6 +68,8 @@ const NewIntakeForm: React.FC = () => {
             <Form<FormData>
                 Input={inputs}
                 onSubmit={onSubmit}
+                loading={formLoading}
+                addButton={extraButtons}
             />
         </div>
     );

--- a/src/app/dashboard/intakes/edit/[intakeId]/page.tsx
+++ b/src/app/dashboard/intakes/edit/[intakeId]/page.tsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import Form from '@/components/Forms';
 import { Intake } from '@/types';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
     intakeName: string;
@@ -20,6 +21,7 @@ const EditIntake = () => {
     const [intake, setIntake] = useState<Intake | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+    const [formLoading, setFormLoading] = useState<boolean>(false);
 
     // Fetch intake data on mount
     useEffect(() => {
@@ -41,7 +43,7 @@ const EditIntake = () => {
 
     // Handle form submission
     const handleSubmit = async (data: FormData) => {
-        console.log(data)
+        setFormLoading(true);
         try {
             await api.put(`/intakes/${intakeId}`, data);
             showToast.success('Intake updated successfully!');
@@ -53,6 +55,9 @@ const EditIntake = () => {
         } catch (err) {
             console.log(err)
             showToast.error('Failed to update intake',);
+        }
+        finally {
+            setFormLoading(false);
         }
     };
 
@@ -67,7 +72,7 @@ const EditIntake = () => {
     };
 
 
-    if (loading) return <div>Loading...</div>;
+    if (loading) return <Loading />
     if (error) return <div className="text-red-500">{error}</div>;
 
     const inputs = [
@@ -79,6 +84,14 @@ const EditIntake = () => {
             options: generateYearOptions()
         }
     ];
+    const extraButtons = [
+        {
+          label: 'Back',
+          type: 'button',
+          onClick: () => router.push('/dashboard/intakes'),
+        }
+      ];
+      
 
     return (
         <div className="p-6">
@@ -88,6 +101,8 @@ const EditIntake = () => {
             <Form<FormData>
                 Input={inputs}
                 onSubmit={handleSubmit}
+                loading={formLoading}
+                addButton={extraButtons}
             />
         </div>
     );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ import {
   FaTimes,
 } from "react-icons/fa";
 import { VscFeedback } from "react-icons/vsc";
-import { PiChalkboardTeacherFill, PiUserCircleDuotone, PiUserCircleGearDuotone } from "react-icons/pi";
+import { PiBellSimpleDuotone, PiChalkboardTeacherFill, PiUserCircleDuotone, PiUserCircleGearDuotone } from "react-icons/pi";
 import { TbUserQuestion } from "react-icons/tb";
 import api from '../../../lib/axios';
 import { ToastContainer } from 'react-toastify';
@@ -190,7 +190,15 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
       viewLink: `/dashboard/user-profile/${user?.id}`,
       icon: <PiUserCircleGearDuotone size={'20px'} />,
       sideIcon: <PiUserCircleGearDuotone size={'30px'} />,
-    }
+    },
+    {
+      name: 'Notification',
+      permission: 'profile',
+      viewLabel: 'Notification',
+      viewLink: `/dashboard/notifications`,
+      icon: <PiBellSimpleDuotone size={'20px'} />,
+      sideIcon: <PiBellSimpleDuotone size={'30px'} />,
+    },
   ];
 
   const menuItems = [
@@ -201,6 +209,14 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
       viewLink: `/dashboard/user-profile/${user?.id}`,
       icon: <PiUserCircleGearDuotone size={'20px'} />,
       sideIcon: <PiUserCircleGearDuotone size={'30px'} />,
+    },
+    {
+      name: 'Notification',
+      permission: 'receive_notifications',
+      viewLabel: 'Notification',
+      viewLink: `/dashboard/notifications`,
+      icon: <PiBellSimpleDuotone size={'20px'} />,
+      sideIcon: <PiBellSimpleDuotone size={'30px'} />,
     },
   ]
 
@@ -280,6 +296,19 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
             <div className="max-h-[calc(100vh-4rem)] overflow-y-auto overflow-scroll">  {/* Allows vertical scroll */}
               <ul className="space-y-2">
                 {tabs.map((tab) => (
+                  user.permissions.includes(tab.permission) && (
+                    <li key={tab.name}>
+                      <button
+                        onClick={() => handleTabChange(tab.name, 'view')}
+                        className={`flex items-center w-full p-2 rounded hover:bg-gray-700 ${activeTab === tab.name ? 'bg-gray-700' : ''} transition-colors`}
+                      >
+                        <span>{tab.sideIcon}</span>
+                        <span className="ml-2">{tab.name}</span>
+                      </button>
+                    </li>
+                  )
+                ))}
+                {menuItems.map((tab) => (
                   user.permissions.includes(tab.permission) && (
                     <li key={tab.name}>
                       <button
@@ -372,6 +401,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
                         </div>
                       </label>
                       {menuItems.map((options) => (
+                        user.permissions.includes(options.permission) && (
                         <label
                           onClick={() => { handleTabChange(options.name, 'view'); setMenuOpen(!menuOpen) }}
                           key={options.name}
@@ -382,6 +412,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
                             <span className="m-1">{options.name}</span>
                           </div>
                         </label>
+                        )
                       ))}
                       <label
                         onClick={() => { handleLogout(); setMenuOpen(!menuOpen) }}
@@ -444,7 +475,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
                   <div>
                     {analytics}
                   </div>
-                )}                
+                )}
                 {activeTab === 'Dashboard' && (
                   <div>
                     {recentactivities}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -27,6 +27,7 @@ import Loading from './loading';
 import istLogo from '../../../public/assets/image/cropedImag.png';
 import Image from 'next/image';
 import { showToast } from '@/components/ToastMessage';
+import { usePathname } from 'next/navigation'
 
 type DashboardLayoutProps = {
   children: React.ReactNode;
@@ -38,13 +39,14 @@ type DashboardLayoutProps = {
 
 const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, analysis, analytics, recentactivities }) => {
   const { user } = useUser();
+  const path = usePathname();
   const router = useRouter(); // Router instance for programmatic navigation
-  const [activeTab, setActiveTab] = useState<string>('Dashboard'); // Default to 'Dashboard' tab
-  const [currentView, setCurrentView] = useState<string>('view'); // For toggling between view/create
+  const [activeTab, setActiveTab] = useState<string>(''); // Default to 'Dashboard' tab
+  const [currentView, setCurrentView] = useState<string>(''); // For toggling between view/create
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false); // State to manage sidebar visibility
   const [menuOpen, setMenuOpen] = useState<boolean>(false); // State to menu visibility
   const [loggedInUser] = useState<string | null>(user?.username ?? null);
-
+  const [currentPath, setCurrentPath] = useState<string>('');
 
   // Function to handle logout
   const handleLogout = async () => {
@@ -63,11 +65,51 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     }
   };
 
+  useEffect(() => {
+    const savedTab = localStorage.getItem("activeTab");
+    const savedView = localStorage.getItem("currentView");
+    const savedPath = localStorage.getItem("currentPath");
+  
+    if (savedTab && savedView && savedPath) {
+      // All required values are in localStorage
+      setActiveTab(savedTab);
+      setCurrentView(savedView);
+      router.push(savedPath);
+    } else if (user && user.permissions.includes("view_dashboard")) {
+      // Defaults to Dashboard if permissions allow
+      const defaultTab = "Dashboard";
+      const defaultView = "view";
+      const defaultPath = "/dashboard"; // Adjust this to your default path
+  
+      setActiveTab(defaultTab);
+      setCurrentView(defaultView);
+  
+      localStorage.setItem("activeTab", defaultTab);
+      localStorage.setItem("currentView", defaultView);
+      localStorage.setItem("currentPath", defaultPath);
+    } else {
+      // Optional: Handle other cases if needed
+      console.log("No saved state and no permissions for default view");
+    }
+  }, [router, user]);
+
+  useEffect(() => {
+      setCurrentPath(path);
+      // Save to localStorage if activeTab, currentView, and currentPath exist
+      if (activeTab && currentView && currentPath) {
+        localStorage.setItem("activeTab", activeTab);
+        localStorage.setItem("currentView", currentView);
+        localStorage.setItem("currentPath", currentPath);
+      }
+  }, [activeTab, currentView, currentPath, path]);
+  
   // Main tabs data with view/create links
   const tabs = [
     {
       name: 'Dashboard',
       permission: 'view_dashboard', // A common permission for all users
+      viewPermission: "view_dashboard",
+      createPermission: "view_dashboard",
       viewLabel: 'Dashboard',
       icon: <RiDashboard2Fill size={'40px'} />,
       sideIcon: <RiDashboard2Fill size={'30px'} />,
@@ -76,6 +118,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: 'User',
       permission: 'manage_users',
+      viewPermission: "view_users",
+      createPermission: "create_users",
       viewLabel: 'View Users',
       createLabel: 'Create User',
       viewLink: '/dashboard/users',
@@ -86,6 +130,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: 'Course',
       permission: 'manage_courses',
+      viewPermission: "view_courses",
+      createPermission: "create_courses",
       viewLabel: 'View Courses',
       createLabel: 'Create Course',
       viewLink: '/dashboard/courses',
@@ -96,6 +142,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: "Module ",
       permission: "manage_modules",
+      viewPermission: "view_modules",
+      createPermission: "create_modules",
       viewLabel: "View Modules",
       createLabel: "Create Module",
       viewLink: "/dashboard/modules",
@@ -106,6 +154,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: "Intake ",
       permission: "manage_intakes",
+      viewPermission: "view_intakes",
+      createPermission: "create_intakes",
       viewLabel: "View Intakes",
       createLabel: "Create Intake",
       viewLink: "/dashboard/intakes",
@@ -116,6 +166,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: "Class Time",
       permission: "manage_class_time",
+      viewPermission: "view_class_times",
+      createPermission: "create_class_times",
       viewLabel: "View Class Times",
       createLabel: "Create Class Time",
       viewLink: "/dashboard/class-times",
@@ -126,6 +178,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: 'Role',
       permission: 'manage_roles',
+      viewPermission: "view_roles",
+      createPermission: "create_roles",
       viewLabel: 'View Roles',
       createLabel: 'Create Role',
       viewLink: '/dashboard/roles',
@@ -136,6 +190,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     {
       name: 'Permission',
       permission: 'manage_permissions',
+      viewPermission: "view_permissions",
+      createPermission: "create_permissions",
       viewLabel: 'View Permissions',
       createLabel: 'Create Permission',
       viewLink: '/dashboard/permissions',
@@ -157,6 +213,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
       name: "Feedback Questions",
       permission: "manage_feedback_questions",
       viewLabel: "View Feedback Question",
+      viewPermission: "view_feedback_questions",
+      createPermission: "create_feedback_questions",
       createLabel: "Create Feedback Question",
       viewLink: "/dashboard/feedback-questions",
       icon: <TbUserQuestion size={"40px"} />,
@@ -167,6 +225,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
       name: "Feedback",
       permission: "manage_feedback",
       viewLabel: "View Feedback",
+      viewPermission: "view_feedbacks",
+      createPermission: "create_feedbacks",
       createLabel: "Create Feedback",
       viewLink: "/dashboard/feedback",
       icon: <VscFeedback size={"40px"} />,
@@ -229,28 +289,15 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
     if (tab) {
       setActiveTab(tab.name); // Set the active tab
       setCurrentView(view); // Set the view mode (view/create)
-
+  
       const newPath: string | undefined = view === 'view' ? tab.viewLink : tab.createLink;
       if (newPath) {
-        router.push(newPath); // Only push if newPath is defined
+        router.push(newPath); // Navigate to the new path
         setSidebarOpen(false); // Close sidebar on navigation
-      } else {
-        console.error("newPath is undefined"); // Handle the undefined case (optional)
       }
     }
   };
-
-  // Set the default tab based on user permissions
-  useEffect(() => {
-    if (user) {
-      if (user.permissions.includes('view_dashboard')) {
-        setActiveTab('Dashboard');
-        setCurrentView('view');
-        router.push('/dashboard'); // Ensure URL is set to dashboard on load
-      }
-    }
-  }, [router, user]);
-
+  
   if (!user || !user.permissions.includes('view_dashboard')) {
     return <div className="text-red-600 text-center mt-20">You do not have access to this page.</div>;
   }
@@ -402,16 +449,16 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
                       </label>
                       {menuItems.map((options) => (
                         user.permissions.includes(options.permission) && (
-                        <label
-                          onClick={() => { handleTabChange(options.name, 'view'); setMenuOpen(!menuOpen) }}
-                          key={options.name}
-                          className={`flex flex-row items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer`}
-                        >
-                          <div className="flex items-center">
-                            <span className="m-1">{options.icon}</span>
-                            <span className="m-1">{options.name}</span>
-                          </div>
-                        </label>
+                          <label
+                            onClick={() => { handleTabChange(options.name, 'view'); setMenuOpen(!menuOpen) }}
+                            key={options.name}
+                            className={`flex flex-row items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer`}
+                          >
+                            <div className="flex items-center">
+                              <span className="m-1">{options.icon}</span>
+                              <span className="m-1">{options.name}</span>
+                            </div>
+                          </label>
                         )
                       ))}
                       <label
@@ -436,7 +483,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
           {/* Sub-tabs for View/Create */}
           {activeTabDetails && (
             <div className="bg-gray-200 p-4 flex space-x-2">
-              {activeTabDetails.viewLabel && (
+              {user.permissions.includes(activeTabDetails?.viewPermission ?? '') && activeTabDetails.viewLabel && (
                 <button
                   onClick={() => handleTabChange(activeTab, 'view')} // Switch to view mode
                   className={`p-2 rounded ${currentView === 'view' ? 'bg-gray-600 text-white' : 'bg-gray-300 hover:bg-gray-400'} transition-colors`}
@@ -444,7 +491,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, overview, a
                   {activeTabDetails.viewLabel}
                 </button>
               )}
-              {activeTabDetails.createLabel && (
+              {user.permissions.includes(activeTabDetails?.createPermission ?? '') && activeTabDetails.createLabel && (
                 <button
                   onClick={() => handleTabChange(activeTab, 'create')} // Switch to create mode
                   className={`p-2 rounded ${currentView === 'create' ? 'bg-gray-600 text-white' : 'bg-gray-300 hover:bg-gray-400'} transition-colors`}

--- a/src/app/dashboard/modules/create/page.tsx
+++ b/src/app/dashboard/modules/create/page.tsx
@@ -18,6 +18,7 @@ const NewModuleForm: React.FC = () => {
   const router = useRouter();
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   useEffect(() => {
     const fetchPermissions = async () => {
       try {
@@ -32,6 +33,7 @@ const NewModuleForm: React.FC = () => {
   }, []);
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/modules", data); // Updated to post to the modules endpoint
       showToast.success("Module created successfully!");
@@ -43,6 +45,9 @@ const NewModuleForm: React.FC = () => {
     } catch (error) {
       console.error("Failed to create module", error);
       showToast.error("Failed to create module");
+    }
+    finally {
+      setFormLoading(false);
     }
   };
   if (loading) return <div>Loading...</div>;
@@ -59,6 +64,14 @@ const NewModuleForm: React.FC = () => {
     }, // Assuming you link the module to a course
   ];
 
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/modules'),
+    }
+  ];
+ 
 
   return (
     <div className="max-w-md mx-auto bg-white p-6 rounded-lg shadow">
@@ -67,6 +80,8 @@ const NewModuleForm: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/modules/edit/[moduleId]/page.tsx
+++ b/src/app/dashboard/modules/edit/[moduleId]/page.tsx
@@ -9,6 +9,7 @@ import Form from '@/components/Forms';
 import { Module } from '@/db/models/Module';
 import { Course } from '@/types';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
   moduleName: string;
@@ -22,7 +23,7 @@ const EditModule = () => {
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   // Fetch module data on mount
   useEffect(() => {
     if (moduleId) {
@@ -56,6 +57,7 @@ const EditModule = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/modules/${moduleId}`, data);
       showToast.success('Module updated successfully!');
@@ -68,9 +70,12 @@ const EditModule = () => {
       console.log(err)
       showToast.error('Failed to update module');
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
   // Form inputs for editing module
@@ -86,6 +91,14 @@ const EditModule = () => {
       }))
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/modules'),
+    }
+  ];
+  
 
   return (
     <div className="p-6">
@@ -94,6 +107,8 @@ const EditModule = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={handleSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Notification } from "@/types";
+import { useEffect, useState } from "react";
+import api from "../../../../lib/axios";
+import Loading from "@/app/loading";
+import Link from "next/link";
+import { useUser } from "@/context/UserContext";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import { showToast } from "@/components/ToastMessage";
+import { useRouter } from 'next/navigation';
+
+const NotificationsPage: React.FC = () => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [deleting, setDeleting] = useState<number | null>(null);
+  const { user } = useUser();
+  const router = useRouter();
+
+  // Fetch notifications on component mount
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      try {
+        const response = await api.get("/notification", {
+          method: "GET",
+          headers: {
+            "user-id": `${user?.id}`,
+          },
+        });
+        setNotifications(response.data.notifications);
+      } catch (error) {
+        console.error("Error fetching notifications:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchNotifications();
+  }, [user?.id]);
+
+  // Mark notification as read
+  const markAsRead = async (id: number) => {
+    try {
+      await api.put(`/notification/${id}`, { status: "read" }); // Assume `status` is the field for read/unread
+      setNotifications((prev) =>
+        prev.map((notification) =>
+          notification.id === id ? { ...notification, status: "read" } : notification
+        )
+      );
+    } catch (error) {
+      console.error("Error marking notification as read:", error);
+    }
+  };
+
+  // Delete notification function
+  const deleteNotification = async (id: number) => {
+    setDeleting(id);
+    try {
+      await api.delete(`/notification/${id}`);
+      setNotifications((prev) => prev.filter((notification) => notification.id !== id));
+      showToast.success("Notification Deleted successfully!");
+    } catch (error) {
+      console.error(error);
+      showToast.error("Error deleting notification");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  // Handle "View Details" click
+  const handleViewDetailsClick = async (id: number, link: string) => {
+    await markAsRead(id); // Mark the notification as read before navigating
+    router.push(link); // Redirect to the notification detail page
+  };
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <ToastContainer />
+      <h1 className="text-2xl font-bold mb-6">Notifications</h1>
+      <div className="bg-white rounded-lg shadow-md p-4">
+        {notifications.length === 0 ? (
+          <p className="text-gray-500">No notifications available.</p>
+        ) : (
+          <ul className="divide-y divide-gray-200">
+            {notifications.map((notification) => (
+              <li
+                key={notification.id}
+                className={`flex items-center justify-between p-4 hover:bg-gray-100 transition ${notification.status === "unread" ? "bg-yellow-50" : ""
+                  }`} // Highlight unread notifications
+              >
+                <div>
+                  <h5 className="text-sm font-semibold">
+                    {notification.status === "unread" && (
+                      <div className="mb-1">
+                        <span className="font-bold text-blue-600">New</span>
+                      </div>
+                    )}
+                    {notification.title}
+                  </h5>
+                  <p className="text-xs text-gray-600">{notification.message}</p>
+                  {notification.link && (
+                    <Link
+                      href="#"
+                      onClick={() => handleViewDetailsClick(notification.id, notification.link)}
+                      className="text-blue-600 hover:underline text-xs mt-1 inline-block"
+                    >
+                      Resolve Notification
+                    </Link>
+                  )}
+                </div>
+
+                <button
+                  onClick={() => deleteNotification(notification.id)}
+                  className="ml-4 flex items-center text-red-600 hover:text-red-800 text-sm font-medium"
+                  disabled={deleting === notification.id}
+                >
+                  {deleting === notification.id ? (
+                    <svg
+                      className="animate-spin h-4 w-4 text-red-600"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                      ></path>
+                    </svg>
+                  ) : (
+                    "Delete"
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotificationsPage;

--- a/src/app/dashboard/permissions/create/page.tsx
+++ b/src/app/dashboard/permissions/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import 'react-toastify/dist/ReactToastify.css';
 import Form from "@/components/Forms";
 import api from "../../../../../lib/axios";
@@ -14,7 +14,9 @@ interface FormData {
 
 const NewPermissionForm: React.FC = () => {
   const router = useRouter();
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/permissions", data);
       showToast.success("Permission created successfully!");
@@ -26,11 +28,22 @@ const NewPermissionForm: React.FC = () => {
       console.error("Failed to create permissions", error);
       showToast.error("Failed to create permissions");
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
   const inputs = [
     { label: "permissionName", type: "text" },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/permissions'),
+    }
+  ];
+ 
 
   return (
     <div className="max-w-md mx-auto bg-white p-6 rounded-lg shadow">
@@ -39,6 +52,8 @@ const NewPermissionForm: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/permissions/edit/[permissionId]/page.tsx
+++ b/src/app/dashboard/permissions/edit/[permissionId]/page.tsx
@@ -8,6 +8,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Form from '@/components/Forms';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
   permissionName: string;
@@ -19,6 +20,7 @@ const EditPermission = () => {
   const [permission, setPermission] = useState<Permission | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   // Fetch user data on mount
   useEffect(() => {
@@ -40,6 +42,7 @@ const EditPermission = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/permissions/${permissionId}`, data);
       showToast.success('permissions updated successfully!');
@@ -52,14 +55,25 @@ const EditPermission = () => {
       console.log(err)
       showToast.error('Failed to update user');
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
   const inputs = [
     { label: "permissionName", type: "text", value: permission?.permissionName }
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/permissions'),
+    }
+  ];
+  
 
   return (
     <div className="p-6">
@@ -69,6 +83,8 @@ const EditPermission = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={handleSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/roles/create/page.tsx
+++ b/src/app/dashboard/roles/create/page.tsx
@@ -8,6 +8,7 @@ import { ToastContainer } from "react-toastify";
 import { useRouter } from "next/navigation";
 import { Permission } from "@/types";
 import { showToast } from "@/components/ToastMessage";
+import Loading from "@/app/loading";
 
 interface FormData {
   roleName: string;
@@ -19,6 +20,7 @@ const CreateRole: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [permissions, setPermissions] = useState<Permission[]>([]);
   const router = useRouter();
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchPermissions = async () => {
@@ -37,6 +39,7 @@ const CreateRole: React.FC = () => {
   }, []);
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       console.log("Form Data Submitted:", data);
       await api.post("/roles", data);
@@ -45,6 +48,9 @@ const CreateRole: React.FC = () => {
     } catch (error) {
       console.error("Failed to create role", error);
       showToast.error("Failed to create role");
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -61,9 +67,17 @@ const CreateRole: React.FC = () => {
       })),
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/roles'),
+    }
+  ];
+  
 
   console.log(permissions);
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
 
 
   return (
@@ -74,6 +88,8 @@ const CreateRole: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/roles/edit/[roleId]/page.tsx
+++ b/src/app/dashboard/roles/edit/[roleId]/page.tsx
@@ -8,6 +8,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Form from '@/components/Forms';
 import { showToast } from '@/components/ToastMessage';
+import Loading from "@/app/loading";
 
 interface FormData {
   permissionName: string;
@@ -21,6 +22,7 @@ const EditRoles = () => {
   const [permissions, setPermissions] = useState<Permission[]>([]);
   const [selectedPermissions, setSelectedPermissions] = useState<number[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   // Fetch user data on mount
   useEffect(() => {
@@ -59,6 +61,7 @@ const EditRoles = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.put(`/roles/${roleId}`, data);
       showToast.success('role updated successfully!');
@@ -71,9 +74,12 @@ const EditRoles = () => {
       console.log(err);
       showToast.error('Failed to update roles');
     }
+    finally {
+      setFormLoading(false);
+    }
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <Loading />
   if (error) return <div className="text-red-500">{error}</div>;
 
   const inputs = [
@@ -88,6 +94,14 @@ const EditRoles = () => {
       })),
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/roles'),
+    }
+  ];
+  
 
   return (
     <div className="p-6">
@@ -97,6 +111,8 @@ const EditRoles = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={handleSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
     </div>
   );

--- a/src/app/dashboard/trainers/create/page.tsx
+++ b/src/app/dashboard/trainers/create/page.tsx
@@ -18,6 +18,7 @@ const NewTrainerForm: React.FC = () => {
   const router = useRouter();
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchCourses = async () => {
@@ -33,6 +34,7 @@ const NewTrainerForm: React.FC = () => {
   }, []);
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post('/trainers', data);
       showToast.success('Trainer created successfully!');
@@ -43,6 +45,9 @@ const NewTrainerForm: React.FC = () => {
     } catch (error) {
       console.error('Failed to create trainer', error);
       showToast.error('Failed to create trainer');
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -58,13 +63,21 @@ const NewTrainerForm: React.FC = () => {
       })),
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/trainers'),
+    }
+  ];
+  
 
   if (loading) return <div>Loading...</div>
   return (
     <div className='max-w-md mx-auto bg-white p-6 rounded-lg shadow'>
       <ToastContainer />
       <h2 className='text-2xl font-bold mb-4'>Create New Trainer</h2>
-      <Form<FormData> Input={inputs} onSubmit={onSubmit} />
+      <Form<FormData> Input={inputs} onSubmit={onSubmit} loading={formLoading} addButton={extraButtons}/>
     </div>
   );
 };

--- a/src/app/dashboard/trainers/edit/[trainerId]/page.tsx
+++ b/src/app/dashboard/trainers/edit/[trainerId]/page.tsx
@@ -23,6 +23,7 @@ const EditTrainer = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [courses, setCourses] = useState<Course[]>([]);
+  const [formLoading, setFormLoading] = useState<boolean>(false);
   // Fetch user data on mount
   useEffect(() => {
     if (trainerId) {
@@ -56,7 +57,7 @@ const EditTrainer = () => {
 
   // Handle form submission
   const handleSubmit = async (data: FormData) => {
-    console.log(data);
+    setFormLoading(true);
     try {
       await api.put(`/trainers/${trainerId}`, data);
       showToast.success('Trainer updated successfully!');
@@ -67,6 +68,9 @@ const EditTrainer = () => {
     } catch (err) {
       console.log(err)
       showToast.error('Failed to update trainer');
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -95,11 +99,19 @@ const EditTrainer = () => {
     },
   ];
 
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/trainers'),
+    }
+  ];
+  
   return (
     <div className='p-6'>
       <ToastContainer />{' '}
       <h3 className='text-2xl font-bold mb-4'>Edit Trainer</h3>
-      <Form<FormData> Input={inputs} onSubmit={handleSubmit} />
+      <Form<FormData> Input={inputs} onSubmit={handleSubmit} loading={formLoading} addButton={extraButtons}/>
     </div>
   );
 };

--- a/src/app/dashboard/user-profile/[userId]/page.tsx
+++ b/src/app/dashboard/user-profile/[userId]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useParams } from 'next/navigation';
+import { useParams,useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import api from '../../../../../lib/axios';
 import Form from '@/components/Forms';
@@ -24,6 +24,7 @@ const UserProfile = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [formLoading, setformLoading] = useState<boolean>(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (userId) {
@@ -65,17 +66,25 @@ const UserProfile = () => {
     { label: "NewPassword", type: "password" },
     { label: "ConfirmNewPassword", type: "password" },
   ];
+  const extraButtons = [
+    {
+      label: 'Clear',
+      type: 'button',
+      onClick: () => router.push('/dashboard'),
+    }
+  ];
+  
   return (
-    <div className="flex flex-col min-h-screen p-1 sm:p-3">
+    <div className="max-w-md mx-auto bg-white p-6 rounded-lg shadow">
       <ToastContainer />
       <div className="flex flex-col min-h-screen p-3 ">
         <h1 className='text-xl'>Update User Profile</h1>
-        <div className="bg-white shadow-md rounded-lg p-6">
           <Form<FormData>
             Input={inputs}
             onSubmit={handleSubmit}
             buttonText="Update"
             loading={formLoading}
+            addButton={extraButtons}
           />
           {/* Password Guidelines Section */}
           <div className="mt-8 bg-gray-100 p-4 rounded-lg shadow-md">
@@ -88,7 +97,6 @@ const UserProfile = () => {
             </ul>
           </div>
 
-        </div>
       </div>
     </div>
 

--- a/src/app/dashboard/users/create/page.tsx
+++ b/src/app/dashboard/users/create/page.tsx
@@ -23,7 +23,7 @@ const NewUserForm: React.FC = () => {
   const [roles, setRoles] = useState<Role[]>([]);
   const [course, setCourse] = useState<Course[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
-
+  const [formLoading, setFormLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchRoles = async () => {
@@ -60,6 +60,7 @@ const NewUserForm: React.FC = () => {
   }, []);
 
   const onSubmit = async (data: FormData) => {
+    setFormLoading(true);
     try {
       await api.post("/users", data);
       showToast.success("User created successfully!");
@@ -70,6 +71,9 @@ const NewUserForm: React.FC = () => {
     } catch (error) {
       console.error("Failed to create user", error);
       showToast.error("Failed to create user");
+    }
+    finally {
+      setFormLoading(false);
     }
   };
 
@@ -94,6 +98,13 @@ const NewUserForm: React.FC = () => {
       })),
     },
   ];
+  const extraButtons = [
+    {
+      label: 'Back',
+      type: 'button',
+      onClick: () => router.push('/dashboard/users'),
+    }
+  ];
 
   if (loading) return <Loading />
 
@@ -105,6 +116,8 @@ const NewUserForm: React.FC = () => {
       <Form<FormData>
         Input={inputs}
         onSubmit={onSubmit}
+        loading={formLoading}
+        addButton={extraButtons}
       />
        {/* Password Guidelines Section */}
        <div className="mt-8 bg-gray-100 p-4 rounded-lg shadow-md">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,7 @@ export default function Home() {
   const { setUser } = useUser();
 
   useEffect(() => {
+
     const checkFeedBackAvailability = async () => {
       try {
         const response = await api.get('/feedback');

--- a/src/app/student-feedback/[feedbackId]/page.tsx
+++ b/src/app/student-feedback/[feedbackId]/page.tsx
@@ -209,7 +209,7 @@ export default function StudentFeedback() {
                     <button
                         type="submit"
                         disabled={isLoading}
-                        className="px-6 py-2 text-lg font-semibold bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+                        className={`px-6 py-2 text-lg font-semibold bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
                     >
                         {isLoading ? (
                             <div className="flex items-center">

--- a/src/components/Forms.tsx
+++ b/src/components/Forms.tsx
@@ -10,7 +10,7 @@ export interface Input {
   label: string;
   type: string;
   require?: boolean;
-  readonly?:boolean;
+  readonly?: boolean;
   value?: string | number;
   valueDate?: Date | null;
   name?: string;
@@ -18,11 +18,22 @@ export interface Input {
   options?: { label: string; value: number | string }[];
 }
 
+export interface Buttons {
+  label: string;
+  type: string;
+  buttonLoading?: boolean;
+  buttonColor?: string;
+  buttonText?: string;
+  hoverColor?: string;
+  onClick: () => void;
+}
+
 interface FormProps<T extends FieldValues> {
   Input: Input[];
   buttonColor?: string;
   buttonText?: string;
   hoverColor?: string;
+  addButton?: Buttons[];
   loading?: boolean;
   buttonVisible?: boolean;
   onSubmit: (data: T) => void;
@@ -35,6 +46,7 @@ interface CustomInputProps {
 const Form = <T extends FieldValues>({
   Input,
   onSubmit,
+  addButton,
   buttonColor,
   buttonText,
   hoverColor,
@@ -286,42 +298,82 @@ const Form = <T extends FieldValues>({
       )
       )}
 
-      {buttonVisible && (
-        <button
-          type="submit"
-          className={`${buttonColor || defaultButtonColor} text-white px-4 py-2 rounded ${hoverColor || defaultHoverColor} ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
-          disabled={loading} // Disable button while loading
-        >
-          {loading ? (
-            <div className="flex items-center">
-              <svg
-                className="animate-spin h-5 w-5 mr-2 text-white"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                ></circle>
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-                ></path>
-              </svg>
-              Submitting...
-            </div>
+      <div className="flex space-x-4">
+        {buttonVisible && (
+          <button
+            type="submit"
+            className={`${buttonColor || defaultButtonColor} text-white px-4 py-2 rounded ${hoverColor || defaultHoverColor} ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
+            disabled={loading} // Disable button while loading
+          >
+            {loading ? (
+              <div className="flex items-center">
+                <svg
+                  className="animate-spin h-5 w-5 mr-2 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                  ></path>
+                </svg>
+                Submitting...
+              </div>
+            ) : (
+              buttonText || defaultButtonText
+            )}
+          </button>
+        )}
 
-          ) : (
-            buttonText || defaultButtonText
-          )}
-        </button>
-      )}
+        {addButton?.map((button, index) => (
+          <button
+            key={index} // Use a unique key for each button
+            type="button"
+            className={`${button.buttonColor || buttonColor || defaultButtonColor} text-white px-4 py-2 rounded ${button.hoverColor || hoverColor || defaultHoverColor} ${button.buttonLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+            onClick={button.onClick} // Attach the onClick handler provided in the Buttons object
+            disabled={button.buttonLoading} // Disable button while loading
+          >
+            {button.buttonLoading ? (
+              <div className="flex items-center">
+                <svg
+                  className="animate-spin h-5 w-5 mr-2 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                  ></path>
+                </svg>
+                Submitting...
+              </div>
+            ) : (
+              button.label || buttonText || defaultButtonText // Use button-specific label if available
+            )}
+          </button>
+        ))}
+      </div>
+
 
     </form>
   );

--- a/src/db/models/Notification.ts
+++ b/src/db/models/Notification.ts
@@ -1,0 +1,81 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../db_connection';
+import { User } from './User';
+
+export class Notification extends Model {
+  id!: number;
+  userId!: number;
+  title!: string;
+  message!: string;
+  link?: string;
+  status!: 'unread' | 'read' | 'archived';
+  priority!: 'low' | 'normal' | 'high';
+  expiresAt?: Date;
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  // Association fields
+  user?: User;
+}
+
+Notification.init({
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+    allowNull: false,
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: User,
+      key: 'id',
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  },
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  message: {
+    type: DataTypes.TEXT, // Allows for longer notification messages
+    allowNull: false,
+  },
+  link: {
+    type: DataTypes.STRING, // Nullable, as not all notifications will have a link
+    allowNull: true,
+  },
+  status: {
+    type: DataTypes.ENUM('unread', 'read', 'archived'),
+    allowNull: false,
+    defaultValue: 'unread',
+  },
+  priority: {
+    type: DataTypes.ENUM('low', 'normal', 'high'),
+    allowNull: false,
+    defaultValue: 'normal',
+  },
+  expiresAt: {
+    type: DataTypes.DATE,
+    allowNull: true, // Nullable for notifications that do not expire
+  },
+  createdAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+}, {
+  sequelize,
+  modelName: 'Notification',
+  tableName: 'Notifications',
+  timestamps: true,
+});
+
+export default Notification;

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -1,8 +1,6 @@
-import { DataTypes, Model} from 'sequelize';
+import { DataTypes, Model } from 'sequelize';
 import sequelize from "../db_connection";
 import { Role } from './Role';
-
-
 
 export class User extends Model {
   id!: number;
@@ -11,6 +9,7 @@ export class User extends Model {
   password!: string;
   roleId!: number;
   courseId!: number;
+  acceptInvite!: boolean; // Add this line to type-check the new property
 }
 
 User.init({
@@ -52,6 +51,11 @@ User.init({
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   },
+  acceptInvite: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: false, // Default value to false
+    allowNull: false, // Ensure it's not nullable
+  },
 }, {
   sequelize,
   modelName: 'User',
@@ -61,5 +65,3 @@ User.init({
 
 User.belongsTo(Role, { as: 'roleUsers', foreignKey: 'roleId' });
 Role.hasMany(User, { foreignKey: 'roleId' });
-
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,14 @@ export interface Module {
   updatedAt: string;
 }
 
+export interface Notification {
+  id: number;
+  title: string;
+  message:string;
+  link:string;
+  status:string;
+}
+
 export interface Feedback {
   id: number;
   trainerId: number;
@@ -102,6 +110,7 @@ export interface User {
   roleId: number;
   createdAt: string;
   updatedAt: string;
+  acceptInvite: boolean;
   roleUsers: {
     id: number;
     roleName: string;
@@ -176,4 +185,11 @@ export interface RecentActivities {
   entityType: string;
   activityType: string;
   description: string;
+}
+
+export interface Button {
+  label: string;
+  type: string;
+  onClick: () => void;
+  buttonLoading?: boolean; // Add this property to make it valid
 }


### PR DESCRIPTION
# Fix Reload Issue and Add Permission-Based Button Visibility

## Description
This PR addresses two major updates:
1. **Fixed Reload Issue**: 
   - Resolved the issue where refreshing the page caused the site to redirect to the dashboard.
   - Implemented logic to persist `activeTab`, `currentView`, and `currentPath` in `localStorage` and use these to maintain the correct state upon page reload.

2. **Permission-Based Button Visibility**:
   - Introduced checks for user permissions (`view` and `create`) to ensure that buttons are only displayed if the user has the appropriate permissions granted by the super admin.

## Changes Made
- Updated the `useEffect` hook to handle state persistence using `localStorage` for `activeTab`, `currentView`, and `currentPath`.
- Added conditional rendering logic to display buttons based on user permissions.

## How to Test
1. **Reload Test**:
   - Navigate to a specific view and refresh the page.
   - Verify that the view and active tab persist without redirecting to the dashboard.

2. **Permission Test**:
   - Log in as a user with different permissions.
   - Verify that buttons are displayed or hidden based on the permissions assigned by the super admin.
